### PR TITLE
Bug fixes for parameters and keep-alive signal

### DIFF
--- a/twitter_stream.py
+++ b/twitter_stream.py
@@ -103,6 +103,10 @@ class API:
                 )
                 response.raise_for_status()
                 for response_lines in response.iter_lines():
+                    # Twitter streaming API will send an empty line At least every 20 seconds to keep the connection open
+                    if len(response_lines) == 0:
+                        continue
+
                     data = json.loads(response_lines)
                     yield data
 

--- a/twitter_stream.py
+++ b/twitter_stream.py
@@ -77,15 +77,12 @@ class API:
     def _query(self) -> dict:
         self._params = {}
         try:
-            [
-                self._params.update(
-                    {v.replace("_", "."): ",".join(self.__class__.__dict__[v])}
-                )
-                for v in self.__class__.__dict__
-                if not callable(getattr(self, v))
-                and not v.startswith("__")
-                and v not in self._exclude
-            ]
+            for v in self.__class__.__dict__:
+                if not callable(getattr(self, v)) and not v.startswith("__"):
+                    vk = v
+                    if v not in self._exclude:
+                        vk = v.replace("_", ".")
+                    self._params[vk]= ",".join(self.__class__.__dict__[v])
             return self._params
         except Exception as e:
             raise e
@@ -350,7 +347,6 @@ class UserLookUp(API):
                         "Authorization": f"Bearer {kwargs['auth']['bearer_token']}",
                     },
                 )
-                print(data.url)
                 data.raise_for_status()
                 for response_lines in data.iter_lines():
                     data = json.loads(response_lines)


### PR DESCRIPTION
Hi,
I encountered two issues when using your library, namely:
- Fields incluced in _exclude list of API enpoint would be ignored altogether instead of using names without does as intended.
- Twitter API can occasionaly send empty line when there are no new tweets to be pulled and this fails on json parsing of recieved lines. Reference: https://developer.twitter.com/en/docs/twitter-api/tweets/filtered-stream/integrate/consuming-streaming-data > Responding to system messages > Keep-alive signals